### PR TITLE
Added logic to set the Gin mode on the metrics server

### DIFF
--- a/pkg/api/examples_test.go
+++ b/pkg/api/examples_test.go
@@ -48,7 +48,9 @@ func exampleHistograms(t, t2 time.Time) {
 }
 
 func Example_Default() {
-	// Create a new metrics router at port 9999
+
+	// default port is 7418; default mode is "debug"
+
 	metrics := NewDefaultMetrics()
 	statSvr := metrics.MetricsSvr
 	svr := httptest.NewServer(statSvr)
@@ -143,8 +145,12 @@ func Example_WithLabels() {
 }
 
 func Example_Customized() {
-	// Create a new metrics router at port 9999
-	metrics := NewMetrics(DefaultStatsPort, &prometheus.Handler{},
+
+	// customize port and mode to 9000 and "release"
+	statsPort := 9000
+	ginMode := "release"
+
+	metrics := NewMetrics(statsPort, ginMode, &prometheus.Handler{},
 		NewStatsEngine("example_with_prefix",
 			stats.T("name", "example"),
 			stats.T("owner", "TJ"),

--- a/pkg/server/examples_test.go
+++ b/pkg/server/examples_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func Example() {
-	// Create a new metrics router at port 9999
+	// Create a new metrics router at port 9999 in debug mode
 	h := &prometheus.Handler{}
 	e := stats.NewEngine("gobot_example", h,
 		stats.T("name", "example"),
 		stats.T("custom", "on all metrics, beware cardinality"))
-	statSvr := NewPrometheusMetricServer(9999, h, e)
+	statSvr := NewPrometheusMetricServer(9999, "debug", h, e)
 	svr := httptest.NewServer(statSvr)
 	defer statSvr.Close()
 	defer svr.Close()

--- a/pkg/server/examples_test.go
+++ b/pkg/server/examples_test.go
@@ -71,12 +71,12 @@ func Example() {
 	// gobot_example_a_guage_only_changes_sometimes{custom="on all metrics, beware cardinality",name="example"} 1 -62142399689877
 	//
 	// # TYPE gobot_example_durations_tracked_this_way histogram
-	// gobot_example_durations_tracked_this_way_count{custom="on all metrics, beware cardinality",name="example"} 2 -62142399689877
-	// gobot_example_durations_tracked_this_way_sum{custom="on all metrics, beware cardinality",name="example"} 101020.158 -62142399689877
+	// gobot_example_durations_tracked_this_way_count{custom="on all metrics, beware cardinality",name="example"} 1 -62142399689877
+	// gobot_example_durations_tracked_this_way_sum{custom="on all metrics, beware cardinality",name="example"} 50510.079 -62142399689877
 	//
 	// # TYPE gobot_example_stats_are_labels counter
-	// gobot_example_stats_are_labels{custom="on all metrics, beware cardinality",name="example"} 22 -62142399689877
+	// gobot_example_stats_are_labels{custom="on all metrics, beware cardinality",name="example"} 11 -62142399689877
 	//
 	// # TYPE gobot_example_stats_can_have_extra_tags_too counter
-	// gobot_example_stats_can_have_extra_tags_too{custom="on all metrics, beware cardinality",name="example",val1="testB"} 2 -62142399689877
+	// gobot_example_stats_can_have_extra_tags_too{custom="on all metrics, beware cardinality",name="example",val1="testB"} 1 -62142399689877
 }

--- a/pkg/server/gin.go
+++ b/pkg/server/gin.go
@@ -5,9 +5,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+type GinMode string
+
 const (
-	GIN_MODE_DEBUG = "debug"
-	GIN_MODE_RELEASE = "release"
+	GIN_MODE_DEBUG GinMode = "debug"
+	GIN_MODE_RELEASE GinMode = "release"
 )
 
 type GinHandler struct {
@@ -20,9 +22,9 @@ type GinHandler struct {
 func NewGinEngine(mode string, middleware []GinHandler, handlers []GinHandler) *gin.Engine {
 
 	//by default, the GIN mode is set to debug
-	if mode == GIN_MODE_DEBUG {
+	if GinMode(mode) == GIN_MODE_DEBUG {
 		gin.SetMode(gin.DebugMode)
-	} else if mode == GIN_MODE_RELEASE {
+	} else if GinMode(mode) == GIN_MODE_RELEASE {
 		gin.SetMode(gin.ReleaseMode)
 	}
 

--- a/pkg/server/gin.go
+++ b/pkg/server/gin.go
@@ -5,6 +5,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	GIN_MODE_DEBUG = "debug"
+	GIN_MODE_RELEASE = "release"
+)
+
 type GinHandler struct {
 	Method HttpMethod        `json:"http_method"`
 	Group  *gin.RouterGroup  `json:"router_group"`
@@ -12,8 +17,17 @@ type GinHandler struct {
 	Path   string            `json:"path"`
 }
 
-func NewGinEngine(middleware []GinHandler, handlers []GinHandler) *gin.Engine {
+func NewGinEngine(mode string, middleware []GinHandler, handlers []GinHandler) *gin.Engine {
+
+	//by default, the GIN mode is set to debug
+	if mode == GIN_MODE_DEBUG {
+		gin.SetMode(gin.DebugMode)
+	} else if mode == GIN_MODE_RELEASE {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
 	engine := gin.Default()
+
 	for _, mw := range middleware {
 		if mw.Group != nil {
 			mw.Group.Use(mw.Funcs...)
@@ -34,6 +48,7 @@ func NewGinEngine(middleware []GinHandler, handlers []GinHandler) *gin.Engine {
 }
 
 func StartGinServer(e *gin.Engine, port int) error {
+
 	if err := e.Run(fmt.Sprintf(":%d", port)); err != nil {
 		return fmt.Errorf("router failed to start: %v", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ const DefaultRouterDebug = false
 
 type Server struct {
 	Port        int `json:"port"`
+	Mode		string `json:"mode"`
 	StatsEngine *stats.Engine
 	Router      *gin.Engine
 	Handler     stats.Handler
@@ -37,19 +38,21 @@ func StatsHandler(h http.Handler) GinHandler {
 	}
 }
 
-func NewDefaultPrometheusMetricServer(port int) *Server {
+func NewDefaultPrometheusMetricServer(port int, mode string) *Server {
 	h := prometheus.DefaultHandler
 	e := stats.DefaultEngine
-	return NewPrometheusMetricServer(port, h, e)
+	return NewPrometheusMetricServer(port, mode, h, e)
 }
 
-func NewPrometheusMetricServer(port int, h stats.Handler, eng *stats.Engine) *Server {
+func NewPrometheusMetricServer(port int, mode string, h stats.Handler, eng *stats.Engine) *Server {
 	eng.Handler = h
 	stats.DefaultEngine = eng
+
 	s := &Server{
 		Port:        port,
+		Mode:		 mode,
 		StatsEngine: eng,
-		Router: NewGinEngine(nil, []GinHandler{
+		Router: NewGinEngine(mode, nil, []GinHandler{
 			StatsHandler(h.(http.Handler)),
 		}),
 		Handler:    h,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -57,7 +57,7 @@ func (t *TestInstanceData) Setup(statPrefix string) {
 		Metrics:     map[string]string{},
 		RealHandler: &prometheus.Handler{},
 	}
-	t.StatsServer = NewPrometheusMetricServer(9999, t.Handler, t.Eng)
+	t.StatsServer = NewPrometheusMetricServer(9999, "release", t.Handler, t.Eng)
 
 	// Attach that Handler to our httptest server
 	t.HttpServer = httptest.NewServer(t.StatsServer)


### PR DESCRIPTION

- Example unit tests in the API package test for both debug and release mode of the Gin Engine and have been verified to be correctly set when setting the mode as either "debug" or "release"
- Default Gin mode has been correctly verified to be "debug" when using the default metrics server using unit tests 