### PR TITLE
Revert "Added logic to set the Gin mode on the metrics server"

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -9,7 +9,6 @@ import (
 )
 
 const DefaultStatsPort = 7418
-const DefaultGinMode = "debug"
 var DefaultStatsHandler = &prometheus.Handler{}
 
 func init() {
@@ -19,7 +18,6 @@ func init() {
 type MetricsConfig struct {
 	Prefix    string `json:"prefix"`
 	StatsPort int    `json:"stats_port"`
-	GinMode   string `jason:"gin_mode"`
 }
 
 type Metrics struct {
@@ -30,24 +28,23 @@ type Metrics struct {
 }
 
 func NewDefaultMetrics() *Metrics {
-	return NewMetrics(DefaultStatsPort, DefaultGinMode, DefaultStatsHandler, NewStatsEngine(""))
+	return NewMetrics(DefaultStatsPort, DefaultStatsHandler, NewStatsEngine(""))
 }
 
-func NewMetrics(port int, mode string, h *prometheus.Handler, eng *stats.Engine) *Metrics {
+func NewMetrics(port int, h *prometheus.Handler, eng *stats.Engine) *Metrics {
 	return &Metrics{
 		Config:       &MetricsConfig{
 			Prefix:    eng.Prefix,
 			StatsPort: port,
-			GinMode:   mode,
 		},
 		StatsHandler: h,
 		MetricsEngine: eng,
-		MetricsSvr:   NewMetricsServer(h, port, mode, eng),
+		MetricsSvr:   NewMetricsServer(h, port, eng),
 	}
 }
 
-func NewMetricsServer(h *prometheus.Handler, port int, mode string, eng *stats.Engine) *metrics.Server {
-	return metrics.NewPrometheusMetricServer(port, mode, h, eng)
+func NewMetricsServer(h *prometheus.Handler, port int, eng *stats.Engine) *metrics.Server {
+	return metrics.NewPrometheusMetricServer(port, h, eng)
 }
 
 func NewStatsEngine(prefix string, tags... stats.Tag) *stats.Engine {
@@ -72,7 +69,7 @@ func (m *Metrics) Run() error {
 	if m.MetricsSvr != nil {
 		svr := m.MetricsSvr
 		*m.MetricsEngine = *m.MetricsSvr.StatsEngine
-		m.MetricsSvr = NewMetricsServer(m.StatsHandler, m.Config.StatsPort, m.Config.GinMode, m.MetricsEngine)
+		m.MetricsSvr = NewMetricsServer(m.StatsHandler, m.Config.StatsPort, m.MetricsEngine)
 		_ = svr.Close()
 	}
 

--- a/pkg/api/examples_test.go
+++ b/pkg/api/examples_test.go
@@ -48,9 +48,7 @@ func exampleHistograms(t, t2 time.Time) {
 }
 
 func Example_Default() {
-
-	// default port is 7418; default mode is "debug"
-
+	// Create a new metrics router at port 9999
 	metrics := NewDefaultMetrics()
 	statSvr := metrics.MetricsSvr
 	svr := httptest.NewServer(statSvr)
@@ -145,12 +143,8 @@ func Example_WithLabels() {
 }
 
 func Example_Customized() {
-
-	// customize port and mode to 9000 and "release"
-	statsPort := 9000
-	ginMode := "release"
-
-	metrics := NewMetrics(statsPort, ginMode, &prometheus.Handler{},
+	// Create a new metrics router at port 9999
+	metrics := NewMetrics(DefaultStatsPort, &prometheus.Handler{},
 		NewStatsEngine("example_with_prefix",
 			stats.T("name", "example"),
 			stats.T("owner", "TJ"),

--- a/pkg/server/examples_test.go
+++ b/pkg/server/examples_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func Example() {
-	// Create a new metrics router at port 9999 in debug mode
+	// Create a new metrics router at port 9999
 	h := &prometheus.Handler{}
 	e := stats.NewEngine("gobot_example", h,
 		stats.T("name", "example"),
 		stats.T("custom", "on all metrics, beware cardinality"))
-	statSvr := NewPrometheusMetricServer(9999, "debug", h, e)
+	statSvr := NewPrometheusMetricServer(9999, h, e)
 	svr := httptest.NewServer(statSvr)
 	defer statSvr.Close()
 	defer svr.Close()
@@ -71,12 +71,12 @@ func Example() {
 	// gobot_example_a_guage_only_changes_sometimes{custom="on all metrics, beware cardinality",name="example"} 1 -62142399689877
 	//
 	// # TYPE gobot_example_durations_tracked_this_way histogram
-	// gobot_example_durations_tracked_this_way_count{custom="on all metrics, beware cardinality",name="example"} 1 -62142399689877
-	// gobot_example_durations_tracked_this_way_sum{custom="on all metrics, beware cardinality",name="example"} 50510.079 -62142399689877
+	// gobot_example_durations_tracked_this_way_count{custom="on all metrics, beware cardinality",name="example"} 2 -62142399689877
+	// gobot_example_durations_tracked_this_way_sum{custom="on all metrics, beware cardinality",name="example"} 101020.158 -62142399689877
 	//
 	// # TYPE gobot_example_stats_are_labels counter
-	// gobot_example_stats_are_labels{custom="on all metrics, beware cardinality",name="example"} 11 -62142399689877
+	// gobot_example_stats_are_labels{custom="on all metrics, beware cardinality",name="example"} 22 -62142399689877
 	//
 	// # TYPE gobot_example_stats_can_have_extra_tags_too counter
-	// gobot_example_stats_can_have_extra_tags_too{custom="on all metrics, beware cardinality",name="example",val1="testB"} 1 -62142399689877
+	// gobot_example_stats_can_have_extra_tags_too{custom="on all metrics, beware cardinality",name="example",val1="testB"} 2 -62142399689877
 }

--- a/pkg/server/gin.go
+++ b/pkg/server/gin.go
@@ -5,13 +5,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type GinMode string
-
-const (
-	GIN_MODE_DEBUG GinMode = "debug"
-	GIN_MODE_RELEASE GinMode = "release"
-)
-
 type GinHandler struct {
 	Method HttpMethod        `json:"http_method"`
 	Group  *gin.RouterGroup  `json:"router_group"`
@@ -19,17 +12,8 @@ type GinHandler struct {
 	Path   string            `json:"path"`
 }
 
-func NewGinEngine(mode string, middleware []GinHandler, handlers []GinHandler) *gin.Engine {
-
-	//by default, the GIN mode is set to debug
-	if GinMode(mode) == GIN_MODE_DEBUG {
-		gin.SetMode(gin.DebugMode)
-	} else if GinMode(mode) == GIN_MODE_RELEASE {
-		gin.SetMode(gin.ReleaseMode)
-	}
-
+func NewGinEngine(middleware []GinHandler, handlers []GinHandler) *gin.Engine {
 	engine := gin.Default()
-
 	for _, mw := range middleware {
 		if mw.Group != nil {
 			mw.Group.Use(mw.Funcs...)
@@ -50,7 +34,6 @@ func NewGinEngine(mode string, middleware []GinHandler, handlers []GinHandler) *
 }
 
 func StartGinServer(e *gin.Engine, port int) error {
-
 	if err := e.Run(fmt.Sprintf(":%d", port)); err != nil {
 		return fmt.Errorf("router failed to start: %v", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,7 +13,6 @@ const DefaultRouterDebug = false
 
 type Server struct {
 	Port        int `json:"port"`
-	Mode		string `json:"mode"`
 	StatsEngine *stats.Engine
 	Router      *gin.Engine
 	Handler     stats.Handler
@@ -38,21 +37,19 @@ func StatsHandler(h http.Handler) GinHandler {
 	}
 }
 
-func NewDefaultPrometheusMetricServer(port int, mode string) *Server {
+func NewDefaultPrometheusMetricServer(port int) *Server {
 	h := prometheus.DefaultHandler
 	e := stats.DefaultEngine
-	return NewPrometheusMetricServer(port, mode, h, e)
+	return NewPrometheusMetricServer(port, h, e)
 }
 
-func NewPrometheusMetricServer(port int, mode string, h stats.Handler, eng *stats.Engine) *Server {
+func NewPrometheusMetricServer(port int, h stats.Handler, eng *stats.Engine) *Server {
 	eng.Handler = h
 	stats.DefaultEngine = eng
-
 	s := &Server{
 		Port:        port,
-		Mode:		 mode,
 		StatsEngine: eng,
-		Router: NewGinEngine(mode, nil, []GinHandler{
+		Router: NewGinEngine(nil, []GinHandler{
 			StatsHandler(h.(http.Handler)),
 		}),
 		Handler:    h,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -57,7 +57,7 @@ func (t *TestInstanceData) Setup(statPrefix string) {
 		Metrics:     map[string]string{},
 		RealHandler: &prometheus.Handler{},
 	}
-	t.StatsServer = NewPrometheusMetricServer(9999, "release", t.Handler, t.Eng)
+	t.StatsServer = NewPrometheusMetricServer(9999, t.Handler, t.Eng)
 
 	// Attach that Handler to our httptest server
 	t.HttpServer = httptest.NewServer(t.StatsServer)


### PR DESCRIPTION
- Reverts orion-labs/metrics#2
- Decided to revert this change in favor of setting the GIN mode via environment variables (as opposed to programmatically)